### PR TITLE
support for specifying a different deb package name than the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Below is the default configuration. The only required parameter is the `configTe
 <configuration>
     <deb>
         <maintainer>Unspecified</maintainer><!-- Optional: The person responsible for this service. -->
+        <name /><!-- Optional: the .deb package name. If not specified, project.artifactId is used. -->
     </deb>
     <jvm>
         <memory>128m</memory><!-- Optional: JVM heap size to allocate, once deployed. -->

--- a/src/main/java/com/jamierf/dropwizard/debpkg/config/DebConfiguration.java
+++ b/src/main/java/com/jamierf/dropwizard/debpkg/config/DebConfiguration.java
@@ -43,7 +43,7 @@ public class DebConfiguration {
     }
     
     public DebConfiguration setName(String name) {
-		this.name = name;
-		return this;
-	}
+        this.name = name;
+        return this;
+    }
 }

--- a/src/main/java/com/jamierf/dropwizard/debpkg/config/DebConfiguration.java
+++ b/src/main/java/com/jamierf/dropwizard/debpkg/config/DebConfiguration.java
@@ -22,11 +22,11 @@ public class DebConfiguration {
     private String name = null;
 
     public String getName() {
-    	if (name != null) {
-    		return name;
-    	} else {
-    		return project.getArtifactId();
-    	}
+        if (name != null) {
+            return name;
+        } else {
+            return project.getArtifactId();
+        }
     }
 
     public String getVersion() {
@@ -42,7 +42,8 @@ public class DebConfiguration {
         return this;
     }
     
-    public void setName(String name) {
+    public DebConfiguration setName(String name) {
 		this.name = name;
+		return this;
 	}
 }

--- a/src/main/java/com/jamierf/dropwizard/debpkg/config/DebConfiguration.java
+++ b/src/main/java/com/jamierf/dropwizard/debpkg/config/DebConfiguration.java
@@ -18,8 +18,15 @@ public class DebConfiguration {
     @Parameter
     private String maintainer = "Unspecified";
 
+    @Parameter
+    private String name = null;
+
     public String getName() {
-        return project.getArtifactId();
+    	if (name != null) {
+    		return name;
+    	} else {
+    		return project.getArtifactId();
+    	}
     }
 
     public String getVersion() {
@@ -34,4 +41,8 @@ public class DebConfiguration {
         this.maintainer = maintainer;
         return this;
     }
+    
+    public void setName(String name) {
+		this.name = name;
+	}
 }

--- a/src/test/java/com/jamierf/dropwizard/debpkg/ConfiguredDropwizardMojoTest.java
+++ b/src/test/java/com/jamierf/dropwizard/debpkg/ConfiguredDropwizardMojoTest.java
@@ -30,7 +30,7 @@ public class ConfiguredDropwizardMojoTest extends AbstractDropwizardMojoTest {
     public void testDebParameter() {
         assertNotNull(plugin.deb);
         assertEquals("Jamie Furness", plugin.deb.getMaintainer());
-        assertEquals("test", plugin.deb.getName());
+        assertEquals("AlternativePackageName", plugin.deb.getName());
         assertEquals("1.0", plugin.deb.getVersion());
     }
 

--- a/src/test/resources/com/jamierf/dropwizard/debpkg/configured.xml
+++ b/src/test/resources/com/jamierf/dropwizard/debpkg/configured.xml
@@ -13,6 +13,7 @@
                     <configTemplate>src/test/resources/com/jamierf/dropwizard/debpkg/test.yml</configTemplate>
                     <deb>
                         <maintainer>Jamie Furness</maintainer>
+                        <name>AlternativePackageName</name>
                     </deb>
                     <jvm>
                         <memory>256m</memory>


### PR DESCRIPTION
I'd like to specify a different name but I noticed it was hard-coded to project.artifactId