### PR TITLE
Allow executing a default shell script upon startup

### DIFF
--- a/src/main/resources/files/start.sh
+++ b/src/main/resources/files/start.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+[ -r "/etc/default/{{{project.artifactId}}}" ] && . "/etc/default/{{{project.artifactId}}}"
+
 JAVA_OPTS=$(sed -e '/^[[:space:]]*\/\//d' -e 's|[[:space:]]*//.*| |' -e 's|^| |' {{{path.jvmConfigFile}}} | tr -d "\n")
 JAVA_CMD="java ${JAVA_OPTS} -jar {{{path.jarFile}}} server {{{path.configFile}}}"
 


### PR DESCRIPTION
I'm using the environment variable override feature of dropwizard (http://www.dropwizard.io/manual/core.html#environment-variables), and I need a way to execute a script upon start to set the environment variables.  I've seen other programs work this way, so hopefully this is acceptable.
